### PR TITLE
Update lmu-lecture.sty for new title slide

### DIFF
--- a/.github/workflows/pr-slide-check.yaml
+++ b/.github/workflows/pr-slide-check.yaml
@@ -70,7 +70,7 @@ jobs:
         run: |
           echo "dir=$(Rscript --quiet -e 'cat(.libPaths()[[1]])')" >> $GITHUB_OUTPUT
       - name: Restore R package cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.r-cache.outputs.dir }}
           key: ${{ runner.os }}-r-${{inputs.cache-version }}-${{ hashFiles('scripts/install_r_deps.R') }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,11 @@ exercises/*/.ipynb_checkpoints/
 *.synctex(busy)
 **.pax # pdfannotextractor / pax
 *.pax
+**.bbl
+**.blg
+**.bcf
+**.bcf-SAVE-ERROR
+**.run.xml
 
 #----------------------------------------------------------#
 #  Editor-specific stuff that should generally be ignored  #

--- a/scripts/update-service.sh
+++ b/scripts/update-service.sh
@@ -3,23 +3,27 @@
 # Intended for use in CI, where there is no need for a git history or $ git pull
 # Downloading a tarball from the API is assumed to be faster than running `git clone`, even considering --depth 1 etc.
 
+# Exit on error immediately
+set -euo pipefail
 
-SERVICEURL="https://api.github.com/repos/slds-lmu/lecture_service/tarball/main"
+# Use the main branch as default target or first argument $1 if specified
+SERVICEBRANCH="${1:-main}" 
+SERVICEURL="https://api.github.com/repos/slds-lmu/lecture_service/tarball/${SERVICEBRANCH}"
 CURRENTDIR="$(basename $PWD)"
 TEMPDIR=$(mktemp --directory)
 CMD="curl -sL $SERVICEURL | tar -xz --directory=$TEMPDIR --strip-components=1"
 
-if [[ $CURRENTDIR == lecture_service ]]
+if [[ "$CURRENTDIR" == lecture_service ]]
 then
-  echo "! This script should be run in the lecture repo (e.g. lecture_i2ml), \033[1mnot\033[22m the service repo!"
+  echo -e "! This script should be run in the lecture repo (e.g. lecture_i2ml), \033[1mnot\033[22m the service repo!"
   exit 1
 fi
 
 
-if [[ $CURRENTDIR != lecture_* ]]
+if [[ "$CURRENTDIR" != lecture_* ]]
 then
   echo "! This does not look like a lecture repo!"
-  echo "! Make sure your current working directory is e.g. \033[1mlecture_i2ml\033[22m, rather than a subdirectory."
+  echo -e "! Make sure your current working directory is e.g. \033[1mlecture_i2ml\033[22m, rather than a subdirectory."
   exit 1
 fi
 
@@ -29,10 +33,13 @@ then
   exit 1
 fi
 
-echo "- Updating service components from https://github.com/slds-lmu/lecture_service/tree/main/service"
+echo -e "- Updating service components from  \033[1m\"$SERVICEBRANCH\"\033[22m branch using"
+echo "    URL: $SERVICEURL"
+echo "    Temporary download directory: $TEMPDIR"
 echo "- Running: "
-echo "  $CMD"
+echo -e "    $CMD"
 eval "$CMD"
+
 
 # Note that using e.g. cp -r .../service/* would not include .-files as they are not expanded by *
 # using cp -r .../service/ on linux copied the service dir itself, jence using rsync for correct behavior

--- a/slides/README.md
+++ b/slides/README.md
@@ -27,13 +27,13 @@ slides/<topic>/figure/
 
 respectively.
 
-## Important files:
+### Important files:
 
 - `tex.mk`: Used as `Makefile` in topic subdirectories. Used to render files for which the source has changed.
   You can try it locally by editing a `.tex` file of a subchapter and then call `make most` in the `slides/<topic>` directory.
 - `R.mk`: Analogously, but this attempts to execute all `fig-*.R` scripts to recreate figures.
 
-### Important workflows:
+### Workflows:
 
 - Edit files via Overleaf ("the prof workflow"), ensure changes are synced back to GitHub
   - You can not run Makefiles on Overleaf
@@ -59,3 +59,62 @@ respectively.
 - Render all slides in a subchapter with margins: `make most`
 - Render all slides in a subchapter without margins: `make most-normargin`
 
+## Slide editing
+
+Some common parts relevant to the slide editing such as custom macros are described here and should be kept in mind by everyone working on the slides.
+
+### Figure paths
+
+A general issue arising when using Overleaf and local commands is that on overleaf, figure paths are autocompleted relative to the project root, i.e. `slides/<topic>/figure_man/foo.pdf`, but for local compilation, it is necessary for paths to be relative to the `<slide-name>.tex` file, e.g. `figure_man/foo.pdf`.
+
+There is an [automated workflow](https://github.com/slds-lmu/lecture_service/blob/main/service/.github/workflows/fix-figure-paths.yaml) that checks and corrects for this installed in every lecture repo (ideally) using GitHub Actions.  
+It automatically creates a pull request to apply the fixes as needed..
+
+### Title Slide
+
+The title slide is defined by a macro `\titlemeta`, which looks as such:
+
+```latex
+\title{Introduction to Machine Learning}
+
+\begin{document}
+
+\titlemeta{% Chunk title (example: CART, Forests, Boosting, ...), can be empty
+  CART
+  }{% Lecture title  
+  Advantages \& Disadvantages
+  }{% Relative path  (to slide .tex) to title page image: Can be empty and must not start with slides/
+  figure_man/some_figure.pdf
+  }{% Learning goals
+    \item First learning goal
+    \item second learning goal
+}
+```
+
+This will take the title of the lecture (`\title{...}`) and the arguments of the macro to produce
+a title slide with headings as such:
+
+```
+Introduction to Machine Learning  
+
+CART  
+Advantages & Disadvantages
+```
+
+And a figure (left) next to the itemized list of learning goals (right).
+
+Other commands such as `\institute`, `\author` or `\date` are superfluous and ignored.
+Command `\lecture` and `\lecturechapter` are used within `\titlemeta`, so they should not be used in the `<slide-name>.tex` file.
+
+### Cite button
+
+The new cite button (as of 2024-05) is called `\citelink` and supersedes the old `\citebutton` command.
+
+In `<slide-name>.tex` files, use `\citelink{BIBREF}`, where `BIRBEF` must(!) be all-caps and a cite-key defined in a `references.bib`.
+
+- Each `lecture_XYZ/slides/<topic>` subfolder has it's own `references.bib`. 
+- Since biblatex/biber/latexmk will look for these files in the same directory as the .tex file, this is a hard requirement for now.
+
+The preamble is set up such that package `biblatex` is only loaded if a `references.bib` is detected to avoid spurious errors.   
+Note that the `biber` command must be available in `$PATH` / by `latexmk` for this to work.  
+This should be the case ofr a normal LaTeX installation, but debugging is hard.

--- a/slides/tex.mk
+++ b/slides/tex.mk
@@ -104,6 +104,9 @@ texclean:
 	-rm -rf *.vrb
 	-rm -rf *.fls
 	-rm -rf *.pax
+	-rm -rf *.bbl
+	-rm -rf *.bcf
+	-rm -rf *.run.xml
 	-rm -rf *.fdb_latexmk
 	-rm -rf *.synctex.gz
 	-rm -rf *-concordance.tex

--- a/style/lmu-lecture.sty
+++ b/style/lmu-lecture.sty
@@ -160,7 +160,7 @@
         \includeGraphicsColumn{#3}
       \fi
 
-      \if\relax\detokenize{#3}\relax\else%
+      \if\relax\detokenize{#4}\relax\else%
         % Same idea with learning goals column
         \includeLearningGoalsColumn{#4}
       \fi

--- a/style/lmu-lecture.sty
+++ b/style/lmu-lecture.sty
@@ -98,6 +98,7 @@
     {\normalsize\bfseries Learning goals}
     \normalfont
     \begin{itemize}
+      \small
       #1
     \end{itemize}
   \end{column}%

--- a/style/lmu-lecture.sty
+++ b/style/lmu-lecture.sty
@@ -71,45 +71,107 @@
   ]\item[]\relax}
 {\enditemize}
 
-\AtBeginLecture{%
-  %\usebackgroundtemplate{\includegraphics[width=\paperwidth,height=\paperheight]{../../style/LMU-hintergrund1.png}}
-  \global\advance\c@lecture by -1
-  \begin{frame}[plain]
-    \vspace*{1 cm}
-    \LARGE\bfseries\inserttitle
-    \vspace*{0.5 cm}
+%-------------------------------------------------------------------%
+%   BeginLecture // Title slide                           %
+%-------------------------------------------------------------------%
 
-    \ifx\lecturesection\@empty\relax\else%
-      {\lecturesection}%
-    \fi%
-
-\ifcsname learninggoals\endcsname
-  {\vspace*{0.75 cm}
-  \begin{minipage}{0.45\textwidth}
-  \ifcsname titlefigure\endcsname
-    {\begin{center}
+% Wrapper to insert title figure within a column env
+% Only needed because column is placed in an if/else arm
+% which is not allowed otherwise (I might be wrong)
+\newcommand{\includeGraphicsColumn}[1]{%
+  \begin{column}{.45\textwidth}
     \begin{figure}[!b]
-    \includegraphics[width=0.9\textwidth, keepaspectratio]{\titlefigure}
+    \includegraphics[width=0.9\textwidth, keepaspectratio]{#1}
     \ifcsname titlecaption\endcsname
       \caption*{\titlecaption}
     \fi
     \end{figure}
-  \end{center}}
-  \else
-    $\;$
+  \end{column}%
+}
+
+% Similar wrapper to insert learning goals
+\newcommand{\includeLearningGoalsColumn}[1]{%
+  \begin{column}{.55\textwidth}
+    % Uncomment for visual debugging of columns with red line
+    % \color{blue}\rule{\linewidth}{4pt}
+    % \vfill % No vfill needed if columns are vertically centered
+    {\normalsize\bfseries Learning goals}
+    \normalfont
+    \begin{itemize}
+      #1
+    \end{itemize}
+  \end{column}%
+}
+
+% Needed for trimming whitespace around \titlemeta arguments
+% Seemingly least bad option. See also 
+% https://tex.stackexchange.com/questions/484288/command-for-nulifying-spaces-string-trim-in-latex
+\RequirePackage{trimspaces}
+\newcommand{\trim}[1] {\trim@spaces@noexp{#1}}
+
+% Main title slide wrapper, includes
+% Automatically uses \title{} element to insert lecture title
+% Example title on slide: "CART: Advantages \& Disadvantages"
+% - Argument 1: Chunk title, e.g. CART
+% - Argument 2: Chapter title, e.g. Advantages \& Disadvantages
+% - Argument 3: Relative path to title figure, can be empty, e.g.: figure/cart_dis_1
+% - Argument 4: \item elements for learning goals.
+\newcommand{\titlemeta}[4]{%
+
+  % If chunk title (arg 1) is empty, we just use the lecture title
+  \if\relax\detokenize{#1}\relax
+    % Use lecture title only
+    \lecturechapter{#2}
+  \else%
+    % Otherwise append chunk title and lecture title separated by :
+    % Trim whitespaces from chunk name to avoid space before :
+    \lecturechapter{\trim{#1}:\\#2}
   \fi
-  \end{minipage}
-  \begin{minipage}{0.45\textwidth}
-  \normalsize
-  Learning goals
-        \normalfont
-\footnotesize
-        \begin{itemize}
-          \learninggoals
-        \end{itemize}
-      \end{minipage}}
-\fi
+
+  % Setting title requires use of \title{} command before \begin{document},
+  % sets the title of the lecture as in "Introduction to Machine Learning"  
+  \lecture{\inserttitle}
+
+  \begin{frame}[noframenumbering,plain]
+    \vspace*{1cm}
+    {\LARGE\bfseries\inserttitle}
+    \vspace*{0.5cm}
+
+    % Insert section title defined via \lecturechapter (??)
+    % \par ensures that spacing is ok when linebreak happens
+    \if\lecturesection\@empty\relax\else%
+      {\LARGE\bfseries\lecturesection\par}%
+    \fi%
+
+    \vfill
+
+    % Using columns env to put things side-by-side rather than minipage
+    % see https://latex-beamer.com/tutorials/columns/
+    \begin{columns}[c] % align columns (c)enter or (T)op
+      % if checks if argument (detokenized?) is empty, i.e. equal to \relax
+      \if\relax\detokenize{#3}\relax\else%
+        % column env is wrapped in separate command because
+        % envs aren't allowed directly within if-else arms apparently
+        % Idea is to have learning goals horizontally centered if no figure is used
+        \includeGraphicsColumn{#3}
+      \fi
+
+      \if\relax\detokenize{#3}\relax\else%
+        % Same idea with learning goals column
+        \includeLearningGoalsColumn{#4}
+      \fi
+    \end{columns}%
   \end{frame}
+}
+
+% Workarounds for slide numbering
+% \AtBeginLecture is provided by the beamer class
+% Contents placed at beginning of document
+\AtBeginLecture{%
+  % Decrement counter, so slide 1 is after the title slide 
+  \global\advance\c@lecture by -1
+  % Writing counter to aux file and console
+  % Presumably useful when combining multiple slides to one large tex file to ensure numbering is correct
   \immediate\write\@auxout {\string \newlabel{lect:@@\thelecture}{{\insertframenumber}}}%
   \typeout{[LECTURE]=[\thelecture][\insertlecture][\thepage][\theframenumber]}%
   \usebackgroundtemplate{}

--- a/style/lmu-lecture.sty
+++ b/style/lmu-lecture.sty
@@ -111,7 +111,10 @@
 
 % Main title slide wrapper, includes
 % Automatically uses \title{} element to insert lecture title
-% Example title on slide: "CART: Advantages \& Disadvantages"
+% Example title on slide: 
+%   CART
+%   Advantages \& Disadvantages
+% -------------------------------
 % - Argument 1: Chunk title, e.g. CART
 % - Argument 2: Chapter title, e.g. Advantages \& Disadvantages
 % - Argument 3: Relative path to title figure, can be empty, e.g.: figure/cart_dis_1
@@ -123,9 +126,9 @@
     % Use lecture title only
     \lecturechapter{#2}
   \else%
-    % Otherwise append chunk title and lecture title separated by :
-    % Trim whitespaces from chunk name to avoid space before :
-    \lecturechapter{\trim{#1}:\\#2}
+    % Otherwise append chunk title and lecture title separated by newline
+    % Trim whitespaces from chunk name to avoid superflusous spaces
+    \lecturechapter{\trim{#1}\\#2}
   \fi
 
   % Setting title requires use of \title{} command before \begin{document},
@@ -347,14 +350,16 @@
 \defbeamertemplate*{headline}{lecture theme}{}
 
 %-------------------------------------------------------------------%
-%   Citebutton                                                      %
+%   Citebutton (superseded by \citelink defined in preamble.tex)    %
 %-------------------------------------------------------------------%
 
+% This version is superseded and \citelink will likely be defined here once widely adopted
 % Example usage (from slides-cart-discussion.tex)
 % \citebutton{Breiman, 1984}{https://www.taylorfrancis.com/books/mono/10.1201/9781315139470/classification-regression-trees-leo-breiman}
 \newcommand{\citebutton}[2]{%
-\NoCaseChange{\resizebox{!}{9pt}{\protect\beamergotobutton{\href{#2}{#1}}}}%
+  \NoCaseChange{\resizebox{!}{9pt}{\protect\beamergotobutton{\href{#2}{#1}}}}%
 }
+
 
 %-------------------------------------------------------------------%
 %   Environments                                                    %

--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -93,6 +93,7 @@
 % telltale error in log would be e.g. Package biblatex Info: ... file 'authoryear.dbx' not found
 % aside from obvious "biber: command not found" or similar.
 
+\usepackage{textcase} % for \NoCaseChange
 \usepackage{hyperref}
 
 % Only try adding a references file if it exists, otherwise

--- a/style/preamble.tex
+++ b/style/preamble.tex
@@ -87,6 +87,29 @@
 \usepackage{framed}
 
 %--------------------------------------------------------%
+%       Cite button (version 2024-05)
+%--------------------------------------------------------%
+% Note this requires biber to be in $PATH when running,
+% telltale error in log would be e.g. Package biblatex Info: ... file 'authoryear.dbx' not found
+% aside from obvious "biber: command not found" or similar.
+
+\usepackage{hyperref}
+
+% Only try adding a references file if it exists, otherwise
+% this would compile error when references.bib is not found
+\IfFileExists{references.bib} {
+  \usepackage{usebib}
+  \usepackage[backend=biber, style=authoryear]{biblatex}
+
+  \addbibresource{references.bib}
+  \bibinput{references}
+}
+
+\newcommand{\citelink}[1]{%
+\NoCaseChange{\resizebox{!}{9pt}{\protect\beamergotobutton{\href{\usebibentry{\NoCaseChange{#1}}{url}}{\begin{NoHyper}\cite{#1}\end{NoHyper}}}}}%
+}
+
+%--------------------------------------------------------%
 %       Displaying code and algorithms
 %--------------------------------------------------------%
 
@@ -131,9 +154,8 @@
 %--------------------------------------------------------%
 
 % wrapfig - Wrapping text around figures https://de.overleaf.com/learn/latex/Wrapping_text_around_figures
-% Provides wrapfigure environment - not used in slides
-% TODO: Check if really unused?
-%\usepackage{wrapfig}
+% Provides wrapfigure environment -used in lecture_optimization
+\usepackage{wrapfig}
 
 % Sub figures in figures and tables
 % https://ctan.org/pkg/subfig -- supersedes subfigure package


### PR DESCRIPTION
This PR adds the new title slide macro `\titlemeta` as introduced in this I2ML PR https://github.com/slds-lmu/lecture_i2ml/pull/1211

The macro should be placed after `\begin{document}` and before the first frame of actual content.

Example from I2ML:

```
\title{Introduction to Machine Learning}

\begin{document}

\titlemeta{% Chunk title (example: CART, Forests, Boosting, ...), can be empty
    CART 
  }{% Lecture title  
    Advantages \& Disadvantages 
  }{% Relative path to title page image: Can be empty but must not start with slides/
  figure/cart_dis_1
  }{
  \item Understand the advantages and disadvantages of CART
  \item Know when and where CART are applied
}

\begin{vbframe}{Second Slide}
```

Please note that this supersedes the following commands that were part of the slide setup before, which can and should be removed:

- `\newcommand{\titlefigure}{figure/....pdf}`
- `\newcommand{\learninggoals}{ ....`
- `\author{...}` has been defunct for a while it seems
- `\institute{...}` is no longer part of he title slide, as unused
- `\date{}` was only there to clear the field, which is now just ommitted from the title slide.
- `\lecturechapter{CART: \\ Computational Aspects of Finding Splits}` incorporated in the macro now
- `\lecture{Introduction to Machine Learning}` also now part of the macro's internals.

Notably the `\title{<Name of Lecture>}` command is still required until I figure out a way to automate that cleanly.


