### PR TITLE
slides compilation fixes

### DIFF
--- a/slides/boosting/slides-boosting-cwb-basics2.tex
+++ b/slides/boosting/slides-boosting-cwb-basics2.tex
@@ -26,7 +26,7 @@
   %\item Fair base learner selection
 }
 
-\begin{vbframe}{Handling of categorical features}
+\begin{frame2}{Handling of categorical features}
 
 Feature $x_j$ with $G$ categories. Two options for encoding:
 
@@ -44,7 +44,8 @@ Feature $x_j$ with $G$ categories. Two options for encoding:
   %\item The \texttt{compboost} package currently implements the first variant.
 
 % ------------------------------------------------------------------------------
-\framebreak
+\end{frame2}
+\begin{frame2}{Handling of categorical features}
 
 Advantages of simultaneously handling all categories in CWB: 
 \begin{itemize}
@@ -69,7 +70,8 @@ Advantages of simultaneously handling all categories in CWB:
 %\end{itemize}
 
 % ------------------------------------------------------------------------------
-\framebreak
+\end{frame2}
+\begin{frame2}{Handling of categorical features}
 
 Advantages of including categories individually in CWB: 
 \begin{itemize}
@@ -92,11 +94,11 @@ Disadvantage of individually handling all categories in CWB:
         Penalization and selection become difficult since base learner has exactly one degree of freedom.
 \end{itemize}
 
-\end{vbframe}
+\end{frame2}
 
 % ------------------------------------------------------------------------------
 
-\begin{vbframe}{intercept handling}
+\begin{frame2}{intercept handling}
 %\vspace{0.2cm}
 There are two options to handle the intercept in CWB. In both, the loss-optimal constant $\fm[0](\xv)$ is an initial model intercept. \\
 %\vspace{0.3cm}
@@ -125,28 +127,25 @@ There are two options to handle the intercept in CWB. In both, the loss-optimal 
 
 %-----------------------------------
 
-\begin{comment}
     
-\begin{itemize}
+% \begin{itemize}
   %\item The loss-optimal constant $\fm[0](\xv)$ is an initial model intercept.
   %\item An intercept is often referred to as part of a model which contains information independent of the features.
-  \item Suppose linear base learners $b_j(\xv) = \theta_{j1} + \theta_{j2} x_j$ with one intercept $\theta_{j1}$ %per base learner
-  and slope $\theta_{j2}$.
-  \item If base learner $\hat{b}_j$ with parameter $\thetamh[1] = (\hat{\theta}_{j1}^{[1]}, \hat{\theta}_{j1}^{[1]})$ is selected in first iteration, model intercept is updated to $\fm[0](\xv) + \hat{\theta}_{j1}^{[1]}$.
-  \item Over the fitting process, the intercept is adjusted $M$ times to its final form:
-    $$
-    \fm[0](\xv) + \sum\limits_{m=1}^M \hat{\theta}^{[m]}_{j^{[m]}1}
-    $$
-\end{itemize}
-$\Rightarrow$ All intercepts in the base learners are collected and aggregated in the model intercept.
+%   \item Suppose linear base learners $b_j(\xv) = \theta_{j1} + \theta_{j2} x_j$ with one intercept $\theta_{j1}$ %per base learner
+%   and slope $\theta_{j2}$.
+%   \item If base learner $\hat{b}_j$ with parameter $\thetamh[1] = (\hat{\theta}_{j1}^{[1]}, \hat{\theta}_{j1}^{[1]})$ is selected in first iteration, model intercept is updated to $\fm[0](\xv) + \hat{\theta}_{j1}^{[1]}$.
+%   \item Over the fitting process, the intercept is adjusted $M$ times to its final form:
+%     $$
+%     \fm[0](\xv) + \sum\limits_{m=1}^M \hat{\theta}^{[m]}_{j^{[m]}1}
+%     $$
+% \end{itemize}
+% $\Rightarrow$ All intercepts in the base learners are collected and aggregated in the model intercept.
+
+% % ------------------------------------------------------------------------------
+% % \framebreak
 
 % ------------------------------------------------------------------------------
-\framebreak
-\end{comment}
 
-% ------------------------------------------------------------------------------
-
-\framebreak
 
 % The following figure shows a comparison of the parameter updates with different intercept handlings:
 % \vspace{0.2cm}
@@ -157,13 +156,13 @@ $\Rightarrow$ All intercepts in the base learners are collected and aggregated i
 % The parameter estimates converge to the same value. The used data set is \href{https://github.com/topepo/AmesHousing}{Ames Housing}.
 
 
-\end{vbframe}
+\end{frame2}
 
 %\input{tex/cwb-bl-sel}
 
 % ------------------------------------------------------------------------------
 
-\begin{vbframe}{Example: Life expectancy}
+\begin{frame2}{Example: Life expectancy}
 
 Consider the \texttt{life expectancy} data set (WHO, available on \sourceref{KUMAR2019KAGGLE})\,: regression task to predict life expectancy. \\
 \vspace{0.1cm}
@@ -186,7 +185,7 @@ We fit a CWB model with linear BLs (with intercept)
 \end{table}
 \vspace{0.4cm}
 Using \texttt{compboost} with $M = 150$ iterations, we can visualize which BL was selected when and how the estimated feature effects evolve over time.
-\end{vbframe}
+\end{frame2}
 
 % tex file and figures are created automatically by: rsrc/fig-cwb-anim.R
 \input{tex/fig-cwb-anim}
@@ -194,7 +193,7 @@ Using \texttt{compboost} with $M = 150$ iterations, we can visualize which BL wa
 %%%%% BLIND OUT, include with removing `\if1` and  \fi
 \if1
 
-\begin{vbframe}{example: boston housing}
+\begin{frame2}{example: boston housing}
 
 \begin{minipage}[c]{0.4\textwidth}
   \small
@@ -231,13 +230,15 @@ Using \texttt{compboost} with $M = 150$ iterations, we can visualize which BL wa
   \end{tabular}
 \end{minipage}%
 
-\vfill
+\end{frame2}
+\begin{frame2}{example: boston housing}
 
 \begin{center}
 \includegraphics[width = \textwidth]{figure/compboost-illustration-1.png}
 \end{center}
 
-\framebreak
+\end{frame2}
+\begin{frame2}{example: boston housing}
 
 % ------------------------------------------------------------------------------
 
@@ -252,7 +253,7 @@ $\rightarrow$ A sparse linear regression is fitted.
 
 \includegraphics[width = \textwidth]{figure/compboost-illustration-2.png}
 
-\end{vbframe}
+\end{frame2}
 
 
 \fi

--- a/slides/boosting/slides-boosting-gbm-classification.tex
+++ b/slides/boosting/slides-boosting-gbm-classification.tex
@@ -14,14 +14,14 @@
   }{% Lecture title  
   	Gradient Boosting: Classification
   }{% Relative path to title page image: Can be empty but must not start with slides/
-  figure/boosting_classif_title.png
+  figure_man/boosting_classif_title.PNG
   }{
   \item GB for binary classification simply uses
 	  Bernoulli or exponential loss
   \item For multiclass we fit $g$ discriminant functions in parallel
 }
 
-\begin{vbframe}{Binary classification}
+\begin{frame2}{Binary classification}
 
 
 For $\Yspace = \{0, 1\}$, we simply have to select an appropriate loss function, so let us
@@ -44,7 +44,8 @@ Hence, effectively, the pseudo-residuals are $y - \pix$.
 
 Through $\pix = s(\fx)$ we can also estimate posterior probabilities.
 
-\framebreak
+\end{frame2}
+\begin{frame2}{Binary classification}
 %
 
 \begin{itemize}
@@ -59,9 +60,9 @@ Through $\pix = s(\fx)$ we can also estimate posterior probabilities.
 \end{itemize}
 
 
-\end{vbframe}
+\end{frame2}
 
-\begin{vbframe}{Example: 2D Circle data}
+\begin{frame2}{Example: 2D Circle data}
 
 % We now illustrate the boosting iterations for a classification example in a similar manner as we did for regression.
 % However, we will now look at a simulation example with 2 instead of 1 influential features and one binary target variable.
@@ -83,7 +84,7 @@ Through $\pix = s(\fx)$ we can also estimate posterior probabilities.
 
 
 
-\end{vbframe}
+\end{frame2}
 
 \begin{frame}{Example: 2D Circle data}
 BG color is predicted probs on LHS on RHS we show and preds of BL.
@@ -136,7 +137,7 @@ BG color is predicted probs on LHS on RHS we show and preds of BL.
 
 % \section{Gradient Boosting for Multiclass Problems}
 
-\begin{vbframe}{Multiclass problems}
+\begin{frame2}{Multiclass problems}
 
 We proceed as in softmax regression and model a categorical distribution with multinomial / log loss.
 For $\Yspace = \{1, \ldots, g\}$, we create $g$ discriminant functions $\fkx$, one for each class and each one being an \textbf{additive} model of base learners.
@@ -151,7 +152,8 @@ Pseudo-residuals:
 $$-\pd{L(y, f_1(\xv), \ldots, f_g(\xv))}{\fkx} =  \mathds{1}_{\{y = k\}} - \pikx. $$
 
 
-\framebreak
+\end{frame2}
+\begin{frame2}{Multiclass problems}
 
 \begin{algorithm}[H]
   \begin{footnotesize}
@@ -174,7 +176,7 @@ $$-\pd{L(y, f_1(\xv), \ldots, f_g(\xv))}{\fkx} =  \mathds{1}_{\{y = k\}} - \pikx
     \end{footnotesize}
 \end{algorithm}
 
-\end{vbframe}
+\end{frame2}
 
 % \begin{vbframe}{Example: 2D Iris}
 	

--- a/slides/boosting/slides-boosting-gbm-with-trees-2.tex
+++ b/slides/boosting/slides-boosting-gbm-with-trees-2.tex
@@ -14,7 +14,7 @@
   }{% Lecture title  
     Gradient Boosting with Trees 2
   }{% Relative path to title page image: Can be empty but must not start with slides/
-  figure/gbm_leaf_adjustment.pdf
+  figure_man/gbm_leaf_adjustment.pdf
   }{
   \item Loss optimal terminal coefficients
   \item GB with trees for multiclass problems

--- a/slides/feature-selection/slides-fs-filters1.tex
+++ b/slides/feature-selection/slides-fs-filters1.tex
@@ -20,7 +20,7 @@
   \item Know filter methods based on correlation, test statistics, and mutual information.
 }
 
-\begin{vbframe}{Introduction}
+\begin{frame2}{Introduction}
   \vspace{0.4cm}
   \begin{itemize}
   \setlength{\itemsep}{0.8em}
@@ -35,11 +35,11 @@
   \footnotesize{Exemplary filter score ranking for Spam data}
   \end{center}
   
-  \end{vbframe}
+  \end{frame2}
 
 
 
-  \begin{vbframe}{$\chi^2$-statistic}
+  \begin{frame2}{$\chi^2$-statistic}
   \begin{itemize}
     \item Test for independence between categorical $x_j$ and cat. target $y$. Numeric features or targets can be discretized.
     \item Hypotheses: \\
@@ -54,10 +54,10 @@
     where $e_{mk}$ is observed relative frequency of pair $(m,k)$, $\tilde{e}_{mk} = \frac{e_{m \cdot} e_{\cdot k}}{n}$ is expected relative frequency, and $M,K$ are number of values $x_j$ and $y$ can take
     \item The larger $\chi_j^2$, the more dependent is the feature-target combination $\rightarrow$ higher relevance
   \end{itemize}
-  \end{vbframe}
+  \end{frame2}
 
 
-  \begin{vbframe}{Pearson \& Spearman correlation}
+  \begin{frame2}{Pearson \& Spearman correlation}
   \textbf{Pearson correlation $r(x_j, y)$: }
   \begin{itemize}
     \item For numeric features and targets only
@@ -85,7 +85,8 @@
   Use absolute values $|r(x_j, y)|$ for feature ranking:\\
   higher score indicates a higher relevance
 
-  \framebreak
+  \end{frame2}
+  \begin{frame2}{Pearson \& Spearman correlation}
 
   Only \textbf{linear} dependency structure, non-linear (non-monotonic) aspects are not captured:
 
@@ -123,55 +124,53 @@
     % \item A higher score indicates higher relevance of the feature.
   %   \end{itemize}
   % \end{vbframe}
-  \end{vbframe}
+  \end{frame2}
 
-\begin{comment}
-  \begin{vbframe}{Distance correlation}
-  % sources: 
-  %Szekely, G.J., Rizzo, M.L., and Bakirov, N.K. (2007), Measuring and Testing Dependence by Correlation of Distances, Annals of Statistics, Vol. 35 No. 6, pp. 2769-2794. 
-  % http://dx.doi.org/10.1214/009053607000000505
-  %Szekely, G.J. and Rizzo, M.L. (2009), Brownian Distance Covariance, Annals of Applied Statistics, Vol. 3, No. 4, 1236-1265. 
-  % http://dx.doi.org/10.1214/09-AOAS312 
-
-
-  $$
-    r_D(x_j, y) = \sqrt{\frac{c_{D}^2(x_j, y)}{\sqrt{c_{D}^2(x_j, x_j) c_{D}^2(y, y)}}}
-  $$
-  Normed version of \textbf{distance covariance}: 
-  $$c_{D}(x_j, y) = \frac{1}{n^2}\sum^n_{i=1}\sum^n_{k=1} D^{(ik)}_{x_j} D^{(ik)}_{y}$$
-  $$ D^{(ik)}_{x_j} = d\left(x^{(i)}_j, x^{(k)}_j\right) - (\bar{d}^{(i\cdot)}_{x_j} + \bar{d}^{(\cdot k)}_{x_j} - \bar{d}^{(\cdot \cdot)}_{x_j}) $$
-  \begin{itemize}
-  \item $D^{(ik)}_{x_j}$ are the centered pairwise distances.
-  \item $d\left(x^{(i)}_j, x^{(k)}_j\right)$ represents the distances of observations.
-  \item $\bar{d}^{(i\cdot)}_{x_j} = \tfrac{1}{n} \sum^n_{k=1} d\left(x^{(i)}_j, x^{(k)}_j\right)$ represent the mean distances.
+%   \begin{vbframe}{Distance correlation}
+%   % sources: 
+%   %Szekely, G.J., Rizzo, M.L., and Bakirov, N.K. (2007), Measuring and Testing Dependence by Correlation of Distances, Annals of Statistics, Vol. 35 No. 6, pp. 2769-2794. 
+%   % http://dx.doi.org/10.1214/009053607000000505
+%   %Szekely, G.J. and Rizzo, M.L. (2009), Brownian Distance Covariance, Annals of Applied Statistics, Vol. 3, No. 4, 1236-1265. 
+%   % http://dx.doi.org/10.1214/09-AOAS312 
 
 
-  \end{itemize}
-
-  \framebreak
-
-  \begin{itemize}
-    \setlength{\itemsep}{1.6em}
-  \item $0 \leq r_D(x_j, y) \leq 1 \quad \forall  j \in \{1, …, p\}$
-  \item $r_D(x_j, y) = 0$ only if $\xv$ and $y$ are empirically independent (!)
-  \item $r_D(x_j, y) = 1$ for exact linear dependencies
-  \item Assesses strength of \textbf{non-monotonic}, \textbf{non-linear}  dependencies
-  \item Generally applicable, even for ranking multivariate features or non-tabular inputs (text, images, audio, etc.)
-  \item Expensive to compute for large data.
-  \end{itemize}
-
-  \begin{figure}
-  \includegraphics[width = 0.85\textwidth]{figure_man/distance-corre.png}
-  \end{figure}
-  {Comparison of Pearson, Spearman and distance correlation for different dependency structures.}
+%   $$
+%     r_D(x_j, y) = \sqrt{\frac{c_{D}^2(x_j, y)}{\sqrt{c_{D}^2(x_j, x_j) c_{D}^2(y, y)}}}
+%   $$
+%   Normed version of \textbf{distance covariance}: 
+%   $$c_{D}(x_j, y) = \frac{1}{n^2}\sum^n_{i=1}\sum^n_{k=1} D^{(ik)}_{x_j} D^{(ik)}_{y}$$
+%   $$ D^{(ik)}_{x_j} = d\left(x^{(i)}_j, x^{(k)}_j\right) - (\bar{d}^{(i\cdot)}_{x_j} + \bar{d}^{(\cdot k)}_{x_j} - \bar{d}^{(\cdot \cdot)}_{x_j}) $$
+%   \begin{itemize}
+%   \item $D^{(ik)}_{x_j}$ are the centered pairwise distances.
+%   \item $d\left(x^{(i)}_j, x^{(k)}_j\right)$ represents the distances of observations.
+%   \item $\bar{d}^{(i\cdot)}_{x_j} = \tfrac{1}{n} \sum^n_{k=1} d\left(x^{(i)}_j, x^{(k)}_j\right)$ represent the mean distances.
 
 
-  \end{vbframe}
-\end{comment}
+%   \end{itemize}
+
+%   \framebreak
+
+%   \begin{itemize}
+%     \setlength{\itemsep}{1.6em}
+%   \item $0 \leq r_D(x_j, y) \leq 1 \quad \forall  j \in \{1, …, p\}$
+%   \item $r_D(x_j, y) = 0$ only if $\xv$ and $y$ are empirically independent (!)
+%   \item $r_D(x_j, y) = 1$ for exact linear dependencies
+%   \item Assesses strength of \textbf{non-monotonic}, \textbf{non-linear}  dependencies
+%   \item Generally applicable, even for ranking multivariate features or non-tabular inputs (text, images, audio, etc.)
+%   \item Expensive to compute for large data.
+%   \end{itemize}
+
+%   \begin{figure}
+%   \includegraphics[width = 0.85\textwidth]{figure_man/distance-corre.png}
+%   \end{figure}
+%   {Comparison of Pearson, Spearman and distance correlation for different dependency structures.}
+
+
+%   \end{vbframe}
 
 
 
-  \begin{vbframe}{Welch's \MakeLowercase{t}-test}
+  \begin{frame2}{Welch's \MakeLowercase{t}-test}
   \begin{itemize}
   \setlength{\itemsep}{0.6em}
     \item For binary classification with $\Yspace = \{ 0, 1\}$ and numeric features
@@ -192,9 +191,9 @@
 %\footnotesize{Visualization of t-test scores.}
   \end{center}
   
-  \end{vbframe}
+  \end{frame2}
 
-  \begin{vbframe}{AUC/ROC}
+  \begin{frame2}{AUC/ROC}
   \begin{itemize}
     \item For binary classification with $\Yspace = \{ 0, 1\}$ and numeric features
     \item Classify samples using single feature (with thresholds), compute AUC per feature as proxy for its ability to separate classes 
@@ -209,10 +208,10 @@
 
    %\footnotesize{Isabelle Guyon, André Elisseeff (2003). An Introduction to Variable and Feature Selection.  Journal of Machine Learning Research (3) p. 1157-1182.}
    \end{center}
-   \end{vbframe}
+   \end{frame2}
 
 
-  \begin{vbframe}{F-Test}
+  \begin{frame2}{F-Test}
   \begin{itemize}
     \item For multiclass classification ($g \ge 2$) and numeric features
     \item Assesses whether the expected values of a feature $x_j$ within the classes of the target differ from each other
@@ -227,9 +226,9 @@
     where $\bar{x}_{j_k}$ is the sample mean of feature $x_j$ where $y = k$ and $\bar{x_{j}}$ is the overall sample mean of feature $x_j$
   \item A higher F-score indicates higher relevance of the feature
   \end{itemize}
-  \end{vbframe}
+  \end{frame2}
 
-  \begin{vbframe}{Mutual Information (MI)}
+  \begin{frame2}{Mutual Information (MI)}
   $$I(X ; Y) = \E_{p(x, y)} \left[ \log \frac{p(X, Y)}{p(X) p(Y)} \right]$$
 
   \begin{itemize}
@@ -241,7 +240,7 @@
   \item Unlike correlation, MI is defined for both numeric and categorical variables and provides a more general measure of dependence
   \item To estimate MI: for discrete features, use observed frequencies; for continuous features, binning, kernel density estimation is used
   \end{itemize}
-  \end{vbframe}
+  \end{frame2}
 
   \endlecture
 \end{document}

--- a/slides/feature-selection/slides-fs-filters2.tex
+++ b/slides/feature-selection/slides-fs-filters2.tex
@@ -43,72 +43,70 @@
 %
 %\end{vbframe}
 
-\begin{comment}
 
-  \begin{vbframe}{Minimum Redundancy Maximum Relevancy}
-  \begin{itemize}
-    \setlength{\itemsep}{2em}
-    \item Most filter-type methods rank features based on a univariate association score without considering relationships among the features.
-    \begin{itemize}
-    \setlength{\itemsep}{1.5em}
-      \item Features may be correlated and hence, may cause redundancy.
-      \item Selected features cover narrow regions in space.
-    \end{itemize}
-    \item We want the features to be relevant and maximally dissimilar to each other (minimum redundancy).
-    \item Features can be either continuous or categorical.
-  \end{itemize}
-  \end{vbframe}
+  % \begin{vbframe}{Minimum Redundancy Maximum Relevancy}
+  % \begin{itemize}
+  %   \setlength{\itemsep}{2em}
+  %   \item Most filter-type methods rank features based on a univariate association score without considering relationships among the features.
+  %   \begin{itemize}
+  %   \setlength{\itemsep}{1.5em}
+  %     \item Features may be correlated and hence, may cause redundancy.
+  %     \item Selected features cover narrow regions in space.
+  %   \end{itemize}
+  %   \item We want the features to be relevant and maximally dissimilar to each other (minimum redundancy).
+  %   \item Features can be either continuous or categorical.
+  % \end{itemize}
+  % \end{vbframe}
 
-  \begin{vbframe}{\MakeLowercase{M}RMR: Criterion functions}
-  \begin{itemize}
-  \item Let $S \subset \{1, \dots, p \}$ be a subset of features we want to find.
+  % \begin{vbframe}{\MakeLowercase{M}RMR: Criterion functions}
+  % \begin{itemize}
+  % \item Let $S \subset \{1, \dots, p \}$ be a subset of features we want to find.
 
-  $$\min \text{Red}(S), \;\;\;\; \text{Red}(S) = \frac{1}{|S|^2} \sum_{j, l \in S} I_{xx}(x_j, x_l)$$
+  % $$\min \text{Red}(S), \;\;\;\; \text{Red}(S) = \frac{1}{|S|^2} \sum_{j, l \in S} I_{xx}(x_j, x_l)$$
 
-  $$\max \text{Rel}(S), \;\;\;\; \text{Rel}(S) = \frac{1}{|S|} \sum_{j \in S} I_{xy}(x_j, \ydat)$$
+  % $$\max \text{Rel}(S), \;\;\;\; \text{Rel}(S) = \frac{1}{|S|} \sum_{j \in S} I_{xy}(x_j, \ydat)$$
 
-  \item $I_{xx}$ measures the strength of the dependency between two features.
-  \item $I_{xy}$ measures the strength of the dependency between a feature and the target.
-  \item They could be mutual information, correlation, F-statistic, etc.
-  \end{itemize}
+  % \item $I_{xx}$ measures the strength of the dependency between two features.
+  % \item $I_{xy}$ measures the strength of the dependency between a feature and the target.
+  % \item They could be mutual information, correlation, F-statistic, etc.
+  % \end{itemize}
 
 
-  \framebreak
+  % \framebreak
 
-  \begin{itemize}
-  \item To optimize simultainously, the criteria is combined into a single objective function:
-  $$\Psi(S) = (\text{Rel}(S) - \text{Red}(S)) \;\;\;\; \text{ or } \;\;\;\; \Psi(S) = (\text{Rel}(S)/\text{Red}(S))$$
+  % \begin{itemize}
+  % \item To optimize simultainously, the criteria is combined into a single objective function:
+  % $$\Psi(S) = (\text{Rel}(S) - \text{Red}(S)) \;\;\;\; \text{ or } \;\;\;\; \Psi(S) = (\text{Rel}(S)/\text{Red}(S))$$
 
-  \item Exact solution requires $ \order (|\Xspace|^{|S|})$ searches, where $|\Xspace|$ is the number of features and $|S|$ is the number of selected features.
-  \end{itemize}
-  In practice, incremental search methods are used to find near-optimal feature sets defined by $\Psi$:
-  \begin{itemize}
-  \item Suppose we already have a feature set with $m-1$ features $S_{m-1}$.
-  \item Next, we select the $m$-th feature from the set $\bar{S}_{m-1}$ by selecting the feature that maximizes:
-  $$\max_{j \, \in \, \bar{S}_{m-1}} [ I_{xy} (x_j, \ydat) - \frac{1}{|S_{m-1}|} \sum_{l \, \in \, S_{m-1}} I_{xx}(x_j, x_l)  ]$$
-  \item The complexity of this incremental algorithm is $\mathcal{O}(|p| \cdot| S|)$.
-  \end{itemize}
-  \end{vbframe}
+  % \item Exact solution requires $ \order (|\Xspace|^{|S|})$ searches, where $|\Xspace|$ is the number of features and $|S|$ is the number of selected features.
+  % \end{itemize}
+  % In practice, incremental search methods are used to find near-optimal feature sets defined by $\Psi$:
+  % \begin{itemize}
+  % \item Suppose we already have a feature set with $m-1$ features $S_{m-1}$.
+  % \item Next, we select the $m$-th feature from the set $\bar{S}_{m-1}$ by selecting the feature that maximizes:
+  % $$\max_{j \, \in \, \bar{S}_{m-1}} [ I_{xy} (x_j, \ydat) - \frac{1}{|S_{m-1}|} \sum_{l \, \in \, S_{m-1}} I_{xx}(x_j, x_l)  ]$$
+  % \item The complexity of this incremental algorithm is $\mathcal{O}(|p| \cdot| S|)$.
+  % \end{itemize}
+  % \end{vbframe}
 
-  \begin{vbframe}{\MakeLowercase{m}RMR: Algorithm}
+  % \begin{vbframe}{\MakeLowercase{m}RMR: Algorithm}
 
-  \begin{algorithm}[H]
-  \footnotesize
-    \begin{algorithmic}[1]
-      \State Set $S = \emptyset$, $R = \{ 1, \dots, p \}$
-      \State Find the feature with maximum relevancy:
-      $$j^* := \argmax_{j} I_{xy} (x_j, \ydat)$$
-      \State Set $S = \{ j^* \}$ and update $R \leftarrow R \setminus \{j^* \}$
-      \Repeat
-        \State Find feature $x_j$ that maximizes:
-        $$\max_{j \, \in \, R} [ I_{xy} (x_j, \ydat) - \frac{1}{|S|} \sum_{l \, \in \, S} I_{xx}(x_j, x_l)  ]$$
-        \State Update $S \leftarrow S \cup \{j^* \}$ and $R \leftarrow R \setminus \{ j^* \}$
-      \Until{Expected number of features have been obtained or some other constraints are satisfied.}
-      \caption{mRMR algorithm}
-    \end{algorithmic}
-  \end{algorithm}
-  \end{vbframe}
-\end{comment}
+  % \begin{algorithm}[H]
+  % \footnotesize
+  %   \begin{algorithmic}[1]
+  %     \State Set $S = \emptyset$, $R = \{ 1, \dots, p \}$
+  %     \State Find the feature with maximum relevancy:
+  %     $$j^* := \argmax_{j} I_{xy} (x_j, \ydat)$$
+  %     \State Set $S = \{ j^* \}$ and update $R \leftarrow R \setminus \{j^* \}$
+  %     \Repeat
+  %       \State Find feature $x_j$ that maximizes:
+  %       $$\max_{j \, \in \, R} [ I_{xy} (x_j, \ydat) - \frac{1}{|S|} \sum_{l \, \in \, S} I_{xx}(x_j, x_l)  ]$$
+  %       \State Update $S \leftarrow S \cup \{j^* \}$ and $R \leftarrow R \setminus \{ j^* \}$
+  %     \Until{Expected number of features have been obtained or some other constraints are satisfied.}
+  %     \caption{mRMR algorithm}
+  %   \end{algorithmic}
+  % \end{algorithm}
+  % \end{vbframe}
 
   \begin{vbframe}{Filter methods can be misleading}
 

--- a/slides/feature-selection/slides-fs-wrapper.tex
+++ b/slides/feature-selection/slides-fs-wrapper.tex
@@ -38,31 +38,29 @@
 
 \end{vbframe}
 
-\begin{comment}
 
-\begin{vbframe}{Introduction}
+% \begin{vbframe}{Introduction}
 
-    Wrappers have the following components:
-
-
-    \begin{itemize}
-      \item A set of starting values
-      \item Operators to create new points out of the given ones
-      \item A termination criterion
-    \end{itemize}
+%     Wrappers have the following components:
 
 
-    \begin{figure}
-      \includegraphics[width=8cm]{figure_man/varsel_space.png}
-      % \caption{Space of all feature sets for 4 features.
-      % The indicated relationships between the sets insinuate a greedy search strategy which either adds or removes a feature.}
-      % Übersetzung von:
-      % Raum aller Feature-Mengen bei 4 Features. Die eingezeichnete Nachbarschaftsbeziehung unterstellt eine Art ,,gierige'' Suchstrategie, bei der wir entweder ein Feature hinzufügen oder entfernen.}
-    \end{figure}
+%     \begin{itemize}
+%       \item A set of starting values
+%       \item Operators to create new points out of the given ones
+%       \item A termination criterion
+%     \end{itemize}
 
 
-  \end{vbframe}
-\end{comment}
+%     \begin{figure}
+%       \includegraphics[width=8cm]{figure_man/varsel_space.png}
+%       % \caption{Space of all feature sets for 4 features.
+%       % The indicated relationships between the sets insinuate a greedy search strategy which either adds or removes a feature.}
+%       % Übersetzung von:
+%       % Raum aller Feature-Mengen bei 4 Features. Die eingezeichnete Nachbarschaftsbeziehung unterstellt eine Art ,,gierige'' Suchstrategie, bei der wir entweder ein Feature hinzufügen oder entfernen.}
+%     \end{figure}
+
+
+%   \end{vbframe}
 
   \begin{vbframe}{Objective function}
 
@@ -91,51 +89,49 @@
   \end{vbframe}
 
 
-\begin{comment}
- \begin{vbframe}{How difficult is best-subset selection?}
+%  \begin{vbframe}{How difficult is best-subset selection?}
 
-    \begin{itemize}
-    \setlength{\itemsep}{1em}
-      \item Size of search space = $2^p$, i.e., grows exponentially in $p$ as it is the power set of $\{1,\ldots,p\}$
-      \item Finding best subset is discrete combinatorial optimization problem.
-      %also known as $L_0$ regularization.
-     \item It can be shown that this problem unfortunately can not be solved efficiently in general (NP hard; see, e.g., \furtherreading{NATARAJAN1995SPARSE})
-     \item We can avoid having to search the entire space by employing efficient search strategies, moving through the search space in a smart way that finds performant feature subsets
-     %\item By employing efficient search strategories, we can avoid searching the entire space.
-    %\item Of course this does not mean that we have to search the entire space, since there are more efficient search strategies.
-    %  \item Formally spoken: One can show that the problem is NP-hard!
-    %  \item This means that the problem cannot be solved in polynomial (P) time: ${\mathcal{O}} (p^c)$, where $c \in \N$ indicates the degree o the polynom.
-    % \end{blocki}
-    %
-    % \framebreak
-    %
-    % \begin{blocki}{How difficult is it to solve the introduced optimization problem, hence, to find the optimal feature set?}
-    %  \item More precisely, the proof demonstrates that this problem cannot be approximated within any constant, unless P = NP.
-    %
-    %   The latter means, that if you find an algorithm that solves a more difficult class of problems (than this optimization problem) in polynomial time, this implies that you found how to solve all easier problems (including our optimization problem) in polynomial time.
-    % \item \textbf{Attention}: This does not imply that it is useless trying to construct strategies which work in practice!
-    %\item Thus our problem now consists of moving through the search space in a smart and efficient way, thereby finding a particularly good set of features.
-    \end{itemize}
-  \end{vbframe}
+%     \begin{itemize}
+%     \setlength{\itemsep}{1em}
+%       \item Size of search space = $2^p$, i.e., grows exponentially in $p$ as it is the power set of $\{1,\ldots,p\}$
+%       \item Finding best subset is discrete combinatorial optimization problem.
+%       %also known as $L_0$ regularization.
+%      \item It can be shown that this problem unfortunately can not be solved efficiently in general (NP hard; see, e.g., \furtherreading{NATARAJAN1995SPARSE})
+%      \item We can avoid having to search the entire space by employing efficient search strategies, moving through the search space in a smart way that finds performant feature subsets
+%      %\item By employing efficient search strategories, we can avoid searching the entire space.
+%     %\item Of course this does not mean that we have to search the entire space, since there are more efficient search strategies.
+%     %  \item Formally spoken: One can show that the problem is NP-hard!
+%     %  \item This means that the problem cannot be solved in polynomial (P) time: ${\mathcal{O}} (p^c)$, where $c \in \N$ indicates the degree o the polynom.
+%     % \end{blocki}
+%     %
+%     % \framebreak
+%     %
+%     % \begin{blocki}{How difficult is it to solve the introduced optimization problem, hence, to find the optimal feature set?}
+%     %  \item More precisely, the proof demonstrates that this problem cannot be approximated within any constant, unless P = NP.
+%     %
+%     %   The latter means, that if you find an algorithm that solves a more difficult class of problems (than this optimization problem) in polynomial time, this implies that you found how to solve all easier problems (including our optimization problem) in polynomial time.
+%     % \item \textbf{Attention}: This does not imply that it is useless trying to construct strategies which work in practice!
+%     %\item Thus our problem now consists of moving through the search space in a smart and efficient way, thereby finding a particularly good set of features.
+%     \end{itemize}
+%   \end{vbframe}
 
-\begin{frame}{Greedy forward search}
+% \begin{frame}{Greedy forward search}
 
-    \begin{blocki}{}
-      \item Let $S \subset \{1, \dots, p \}$, where $\{1, \dots p \}$ are feature indices
-      \item Start with the empty feature set $S = \emptyset$
-      \item For a given set $S$, generate all $S_j = S \cup \{j\}$ with $j \notin S$.
-      \item Evaluate the classifier on all $S_j$ and use the best $S_j$
-      \item Iterate over this procedure
-      \item Terminate if:
-        \begin{enumerate}
-          \item the performance measure doesn't improve enough
-          \item a maximum number of features is used
-          \item a given performance value is reached
-        \end{enumerate}
-    \end{blocki}
+%     \begin{blocki}{}
+%       \item Let $S \subset \{1, \dots, p \}$, where $\{1, \dots p \}$ are feature indices
+%       \item Start with the empty feature set $S = \emptyset$
+%       \item For a given set $S$, generate all $S_j = S \cup \{j\}$ with $j \notin S$.
+%       \item Evaluate the classifier on all $S_j$ and use the best $S_j$
+%       \item Iterate over this procedure
+%       \item Terminate if:
+%         \begin{enumerate}
+%           \item the performance measure doesn't improve enough
+%           \item a maximum number of features is used
+%           \item a given performance value is reached
+%         \end{enumerate}
+%     \end{blocki}
 
-    \end{frame}
-\end{comment}
+%     \end{frame}
 
 \begin{frame}{Greedy forward search}
 Let $S \subset \{1, \dots, p \}$ be subset of feature indices.
@@ -285,24 +281,22 @@ Let $S \subset \{1, \dots, p \}$ be subset of feature indices.
 
 \end{vbframe}
 
-\begin{comment}
-    \begin{algorithm}[H]
-    \begin{algorithmic}[1]
-      \State Start with a random set of features $S$ (bit vector $b$).
-      \Repeat
-      \State Flip a couple of bits in $b$ with probability $p$
-      \State Generate set $S^\prime$ and bit vector $b^\prime$
-      \State Measure the classifier's performance on $S^\prime$
-      \State If $S^\prime$ performs better than $S$, update $S \leftarrow S^\prime$, otherwise $S \leftarrow S$.
-      \Until One of the following conditions is met:
-        \begin{itemize}
-          \item A given performance value is reached.
-          \item Budget is exhausted.
-        \end{itemize}
-        \caption{A simple 1+1 genetic algorithm}
-    \end{algorithmic}
-    \end{algorithm}
-\end{comment}
+    % \begin{algorithm}[H]
+    % \begin{algorithmic}[1]
+    %   \State Start with a random set of features $S$ (bit vector $b$).
+    %   \Repeat
+    %   \State Flip a couple of bits in $b$ with probability $p$
+    %   \State Generate set $S^\prime$ and bit vector $b^\prime$
+    %   \State Measure the classifier's performance on $S^\prime$
+    %   \State If $S^\prime$ performs better than $S$, update $S \leftarrow S^\prime$, otherwise $S \leftarrow S$.
+    %   \Until One of the following conditions is met:
+    %     \begin{itemize}
+    %       \item A given performance value is reached.
+    %       \item Budget is exhausted.
+    %     \end{itemize}
+    %     \caption{A simple 1+1 genetic algorithm}
+    % \end{algorithmic}
+    % \end{algorithm}
 
 %\framebreak
 %\end{vbframe}
@@ -317,27 +311,25 @@ Let $S \subset \{1, \dots, p \}$ be subset of feature indices.
 %Bit representation of the best variables included up to iteration $t$
 
 % this is in the optim slides regarding featsel using EA
-\begin{comment}
-\textbf{Aim:} Use a $(\mu + \lambda)$ selection strategy for feature selection.\\
-\vspace*{0.2cm}
-Our iterative algorithm with $100$ iterations is as follows:
-\begin{enumerate}
-\item Initialize the population and evaluate it. Therefore, encode a chromosome of an individual as a bit string of length $p$, i.e. $\textbf{z} \in \{0, 1\}^p$. Where $z_j =1$ means that variable $j$ is included in the model.
-\item Apply the variation and evaluate the fitness function. As fitness function, select BIC of the model belonging to the corresponding variable configuration $\textbf{z} \in \{0, 1\}^p$.
-\item Finally, use $(\mu + \lambda)$-selection strategy as the survival selection with population size of $\mu = 100$ and $\lambda =50$ offspring.
-\end{enumerate}
+% \textbf{Aim:} Use a $(\mu + \lambda)$ selection strategy for feature selection.\\
+% \vspace*{0.2cm}
+% Our iterative algorithm with $100$ iterations is as follows:
+% \begin{enumerate}
+% \item Initialize the population and evaluate it. Therefore, encode a chromosome of an individual as a bit string of length $p$, i.e. $\textbf{z} \in \{0, 1\}^p$. Where $z_j =1$ means that variable $j$ is included in the model.
+% \item Apply the variation and evaluate the fitness function. As fitness function, select BIC of the model belonging to the corresponding variable configuration $\textbf{z} \in \{0, 1\}^p$.
+% \item Finally, use $(\mu + \lambda)$-selection strategy as the survival selection with population size of $\mu = 100$ and $\lambda =50$ offspring.
+% \end{enumerate}
 
-In addition:
+% In addition:
 
-\begin{itemize}
-\item for the mutation, use bit flip with $p = 0.3$
-\item for the recombination, use Uniform crossover with $p=0.5$
-\end{itemize}
+% \begin{itemize}
+% \item for the mutation, use bit flip with $p = 0.3$
+% \item for the recombination, use Uniform crossover with $p=0.5$
+% \end{itemize}
 
-\lz
+% \lz
 
-By exploiting \textbf{Greedy} as a selection strategy, ensure that you always choose individuals with the best fitness.
-\end{comment}
+% By exploiting \textbf{Greedy} as a selection strategy, ensure that you always choose individuals with the best fitness.
 
 
 

--- a/slides/linear-svm/slides-linsvm-erm.tex
+++ b/slides/linear-svm/slides-linsvm-erm.tex
@@ -49,16 +49,16 @@ We derived this QP for the soft-margin SVM:
   In the optimum, the inequalities will hold with equality (as we minimize the slacks), so $\sli = 1 - \yi \fxi$, but the lowest value $\sli$ can take is 0 (we do no get a bonus for points beyond the margin on the correct side).
   So we can rewrite the above: 
 \begin{align*} 
-    \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lyf = 
+    \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lxy = 
     \begin{cases} 
       1 - y f & \text{ if } y f \leq 1 \\ 
       0       & \text{ if } y f > 1 
     \end{cases}
 \end{align*} 
-We can also write $\Lyf = \max(1-yf, 0)$.
+We can also write $\Lxy = \max(1-yf, 0)$.
 
 \framebreak
-  $$ \risket = \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lyf = \max(1-yf, 0)$$
+  $$ \risket = \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lxy = \max(1-yf, 0)$$
   \begin{itemize}
     \item This now obviously L2-regularized empirical risk minimization.
     \item Actually, a lot of ERM theory was established when Vapnik (co-)invented the SVM in the beginning of the 90s.
@@ -74,7 +74,7 @@ We can also write $\Lyf = \max(1-yf, 0)$.
 
 \framebreak
 
-  $$ \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lyf = \max(1-yf, 0)$$
+  $$ \frac{1}{2} \|\thetav\|^2 + C \sumin \Lxyi ;\; \Lxy = \max(1-yf, 0)$$
 \begin{itemize}
  \item  The ERM interpretation does not require any of the terms -- the loss or the regularizer -- to be geometrically meaningful.
   \item The above form is a very compact form to define the convex optimization problem of the SVM. 
@@ -89,7 +89,7 @@ We can also write $\Lyf = \max(1-yf, 0)$.
 
   SVMs can easily be generalized by changing the loss function.
   \begin{itemize}
-    \item Squared hinge loss / Least Squares SVM: $\Lyf = \max(0, (1 - yf)^2)$ 
+    \item Squared hinge loss / Least Squares SVM: $\Lxy = \max(0, (1 - yf)^2)$ 
     \item Huber loss (smoothed hinge loss)
     \item Bernoulli/Log loss. This is L2-regularized logistic regression!
     \item NB: These other losses usually do not generate sparse solutions in terms of 

--- a/slides/linear-svm/slides-linsvm-optimization.tex
+++ b/slides/linear-svm/slides-linsvm-optimization.tex
@@ -41,7 +41,7 @@ Unconstrained formulation of soft-margin SVM:
 $$
 \min\limits_{\thetav, \theta_0} \quad \frac{\lambda}{2} \|\thetav\|^2 + \sumin \Lxyit
 $$
-where $\Lyf = \max(0, 1 -  y f)$ and $\fxt = \thetav^T \xv + \theta_0$.\\ 
+where $\Lxy = \max(0, 1 -  y f)$ and $\fxt = \thetav^T \xv + \theta_0$.\\ 
 (We inconsequentially changed the regularization constant.)
 
 \vspace*{2mm}
@@ -85,7 +85,7 @@ We cannot directly use GD, as the above is not differentiable.
 Approximate the risk by a stochastic 1-sample version: 
 \vspace{-0.3cm}
 $$ \frac{\lambda}{2} \|\thetav\|^2 + \Lxyit $$
-With: $\fxt = \thetav^T \xv + \theta_0$ and $\Lyf = \max(0, 1 -  y f)$\\
+With: $\fxt = \thetav^T \xv + \theta_0$ and $\Lxy = \max(0, 1 -  y f)$\\
 The subgradient for $\thetav$ is $\lambda \thetav - \yi \xi \I_{yf < 1}$
 
 \vspace{-0.1cm}

--- a/slides/nonlinear-svm/slides-nonlinsvm-modelsel.tex
+++ b/slides/nonlinear-svm/slides-nonlinsvm-modelsel.tex
@@ -13,7 +13,7 @@
   }{% Lecture title  
     SVM Model Selection
   }{% Relative path to title page image: Can be empty but must not start with slides/
-  figure/rbf_sigma.png
+  figure_man/rbf_sigma.png
   }{
   \item Know that the SVM is sensitive to hyperparameter choices
   \item Understand the effect of different (kernel) hyperparameters

--- a/slides/regularization/references.bib
+++ b/slides/regularization/references.bib
@@ -37,6 +37,16 @@
   url={https://www.jstor.org/stable/2984971}
 }
 
+@article{NEYSHABUR2015,
+      title={In Search of the Real Inductive Bias: On the Role of Implicit Regularization in Deep Learning}, 
+      author={Behnam Neyshabur and Ryota Tomioka and Nathan Srebro},
+      year={2015},
+      eprint={1412.6614},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG},
+      url={https://arxiv.org/abs/1412.6614}, 
+}
+
 @article{THEOBALD1974,
   title={Generalizations of mean square error applied to ridge regression},
   author={Theobald, Chris M},

--- a/slides/regularization/slides-regu-intro.tex
+++ b/slides/regularization/slides-regu-intro.tex
@@ -201,19 +201,17 @@ But we would rather control complexity \textbf{on a continuum}.
 
 \begin{vbframe}{Regularized Empirical Risk Minimization}
 
-\begin{comment}  
-Recall, empirical risk minimization with a complex hypothesis set tends to overfit. A major tool for handling overfitting is \textbf{regularization}.
+% Recall, empirical risk minimization with a complex hypothesis set tends to overfit. A major tool for handling overfitting is \textbf{regularization}.
   
-  \lz
+%   \lz
   
-In the broadest sense, regularization refers to any modification made to a learning algorithm that is intended to reduce its generalization error but not its training error.
+% In the broadest sense, regularization refers to any modification made to a learning algorithm that is intended to reduce its generalization error but not its training error.
   
-  \lz
+%   \lz
   
-Explicitly or implicitly, such modifications represent the preferences we have regarding the elements of the hypothesis set. 
+% Explicitly or implicitly, such modifications represent the preferences we have regarding the elements of the hypothesis set. 
 
-  \framebreak
-\end{comment}  
+%   \framebreak
 
   Common pattern:
   $$

--- a/slides/regularization/slides-regu-l1vsl2.tex
+++ b/slides/regularization/slides-regu-l1vsl2.tex
@@ -114,41 +114,39 @@ $\Sigma_{k,l}=0.7^{|k-l|}$
 
 \framebreak
 
-\begin{comment}
-\textbf{Example:}
-\begin{itemize}
-\item Let the true data generating process be
-$$ y = x_1 + \epsilon, \quad \epsilon \sim \normal \left(0, 1\right).$$
-\item Let there be 5 features $x_1, \ldots, x_5 \sim \normal (0,1)$.
-\item Using the lasso (package \texttt{glmnet}), we get
-\footnotesize
-\vspace{0.2cm}
+% \textbf{Example:}
+% \begin{itemize}
+% \item Let the true data generating process be
+% $$ y = x_1 + \epsilon, \quad \epsilon \sim \normal \left(0, 1\right).$$
+% \item Let there be 5 features $x_1, \ldots, x_5 \sim \normal (0,1)$.
+% \item Using the lasso (package \texttt{glmnet}), we get
+% \footnotesize
+% \vspace{0.2cm}
 
-\begin{table}[]
-\begin{tabular}{lllll}
-(Intercept) & x1    & x2    & x3    & x4    \\
--0.056      & 0.489 & 0.000 & 0.000 & 0.000 
-\end{tabular}
-\end{table}
+% \begin{table}[]
+% \begin{tabular}{lllll}
+% (Intercept) & x1    & x2    & x3    & x4    \\
+% -0.056      & 0.489 & 0.000 & 0.000 & 0.000 
+% \end{tabular}
+% \end{table}
 
 
-\normalsize
-\item But if we rescale any of the noise features, say $x_2 = 10000 \cdot x_2$ and don't use standardization, we get
-\footnotesize
-\vspace{0.2cm}
+% \normalsize
+% \item But if we rescale any of the noise features, say $x_2 = 10000 \cdot x_2$ and don't use standardization, we get
+% \footnotesize
+% \vspace{0.2cm}
 
-\begin{table}[]
-\begin{tabular}{lllll}
-(Intercept) & x1       & x2        & x3       & x4       \\
--0.106830   & 0.000000 & -0.000013 & 0.000000 & 0.000000         
-\end{tabular}
-\end{table}
+% \begin{table}[]
+% \begin{tabular}{lllll}
+% (Intercept) & x1       & x2        & x3       & x4       \\
+% -0.106830   & 0.000000 & -0.000013 & 0.000000 & 0.000000         
+% \end{tabular}
+% \end{table}
 
-\normalsize
+% \normalsize
 
-\item This is due to the fact, that the coefficient of $x_2$ will live on a very small scale as the covariate itself is large. The feature will thus get less penalized by the $L1$-norm and is favored by lasso.
-\end{itemize}
-\end{comment}
+% \item This is due to the fact, that the coefficient of $x_2$ will live on a very small scale as the covariate itself is large. The feature will thus get less penalized by the $L1$-norm and is favored by lasso.
+% \end{itemize}
 
 \end{vbframe}
 

--- a/slides/regularization/slides-regu-l2-nonlin.tex
+++ b/slides/regularization/slides-regu-l2-nonlin.tex
@@ -229,7 +229,7 @@ Chris: I think ChatGPT produced a lot of "almost correct" stuff that culminated 
     \item For fully-connected linear networks using $L$ weight matrices $f(x|W_L,\ldots,W_1)=W_L \cdot \ldots \cdot W_1 x$, adding $L2$ regularization with $\lambda$ to all $W_l$ produces equivalent minma to Schatten $2/L$-norm regularization of the the collapsed linear predictor $\Bar{W}x:=W_L \cdot \ldots \cdot W_1x$ with strength $L\lambda$
     \item I am fairly certain there is also no existence theorem for non-convex Schatten $2/L$-norm regularization, their success depends strongly on the low-rank nature of the problem
     \item For MLPs beyond linear DNNs there are also some results for the "induced regularizer" in specific cases, which is often a complex or non-analytical expression. For these, there are also no existence theorems
-    \item \citebutton{Neyshabur et al., 2015}{https://arxiv.org/pdf/1412.6614} derive equivalent optimization problems for $L2$ regularized shallow relu-networks:
+    \item \furtherreading{NEYSHABUR2015} derive equivalent optimization problems for $L2$ regularized shallow relu-networks:
     $$
 \underset{\boldsymbol{v} \in \mathbb{R}^H,\left(\boldsymbol{u}_h\right)_{h=1}^H}{\operatorname{argmin}}\left(\sum_{t=1}^n L\left(y_t, \sum_{h=1}^H v_h\left[\left\langle\boldsymbol{u}_h, \boldsymbol{x}_t\right\rangle\right]_{+}\right)+\frac{\lambda}{2} \sum_{h=1}^H\left(\left\|\boldsymbol{u}_h\right\|^2+\left|v_h\right|^2\right)\right),
 $$

--- a/slides/regularization/slides-regu-l2.tex
+++ b/slides/regularization/slides-regu-l2.tex
@@ -224,100 +224,98 @@ With an $L2$ penalty we can now select $d$ "too large" but regularize our model 
 
 % \section{Lasso Regression}
 
-\begin{comment}
-\begin{vbframe}{Lasso Regression}
+% \begin{vbframe}{Lasso Regression}
 
-Another shrinkage method is the so-called \textbf{Lasso regression} ({\scriptsize{least absolute shrinkage and selection operator}}), which uses an $L1$ penalty on $\thetav$:
-\vspace{-0.2cm}
-\begin{eqnarray*}
-\thetah_{\text{Lasso}}= \argmin_{\thetav} \underbrace{\sumin \left(\yi - \thetav^T \xi\right)^2}_{\left(\yv - \Xmat \thetav\right)^\top \left(\yv - \Xmat \thetav\right)} + \lambda \|\thetav\|_1
-\end{eqnarray*}
-Optimization is much harder now. $\riskrt$ is still convex, but in general there is no analytical solution and it is non-differentiable.\\
-\vspace{0.2cm}
+% Another shrinkage method is the so-called \textbf{Lasso regression} ({\scriptsize{least absolute shrinkage and selection operator}}), which uses an $L1$ penalty on $\thetav$:
+% \vspace{-0.2cm}
+% \begin{eqnarray*}
+% \thetah_{\text{Lasso}}= \argmin_{\thetav} \underbrace{\sumin \left(\yi - \thetav^T \xi\right)^2}_{\left(\yv - \Xmat \thetav\right)^\top \left(\yv - \Xmat \thetav\right)} + \lambda \|\thetav\|_1
+% \end{eqnarray*}
+% Optimization is much harder now. $\riskrt$ is still convex, but in general there is no analytical solution and it is non-differentiable.\\
+% \vspace{0.2cm}
 
 
-\framebreak
+% \framebreak
 
-Let $y=3x_{1} -2x_{2} +\epsilon $, $ \epsilon \sim N( 0,1)$. The true minimizer is $\theta ^{*} =( 3,-2)^{T}$. Consider $\lambda $ values of 0.01, 0.5, 1, 1.5, 2, 2.5, 10.
+% Let $y=3x_{1} -2x_{2} +\epsilon $, $ \epsilon \sim N( 0,1)$. The true minimizer is $\theta ^{*} =( 3,-2)^{T}$. Consider $\lambda $ values of 0.01, 0.5, 1, 1.5, 2, 2.5, 10.
 
-\begin{figure}
-\includegraphics[width=0.7\textwidth]{figure/lin_model_regu_01.png}
-\end{figure}
+% \begin{figure}
+% \includegraphics[width=0.7\textwidth]{figure/lin_model_regu_01.png}
+% \end{figure}
 
-With increasing regularization, $\theta_{\textit{ridge}}$ is pulled back to the origin. Contours = unreg. objective, dots = reg. solution for increasing $\lambda$.
+% With increasing regularization, $\theta_{\textit{ridge}}$ is pulled back to the origin. Contours = unreg. objective, dots = reg. solution for increasing $\lambda$.
 
-%\textbf{NB}: lasso=least absolute shrinkage and selection operator.
+% %\textbf{NB}: lasso=least absolute shrinkage and selection operator.
 
-\framebreak 
+% \framebreak 
 
-Contours of regularized objective for different $\lambda$ values.
-\begin{figure}
-\includegraphics[width=0.9\textwidth]{figure/reg_contours_01.png}
-\end{figure}
+% Contours of regularized objective for different $\lambda$ values.
+% \begin{figure}
+% \includegraphics[width=0.9\textwidth]{figure/reg_contours_01.png}
+% \end{figure}
 
-\framebreak
+% \framebreak
 
-We can also rewrite this as a constrained optimization problem. The penalty results in the constrained region to look like a diamond shape.
-\vspace{-0.2cm}
-\begin{eqnarray*}
-\min_{\thetav} \sumin \left(\yi - \fxit\right)^2\,
-\text{subject to: } \|\thetav\|_1 \leq t
-\end{eqnarray*}
-The kinks in $L1$ enforce sparse solutions because ``the loss contours first hit the sharp corners of the constraint'' at coordinate axes where (some) entries are zero. 
-\vspace{-0.1cm}
-\begin{figure}%\includegraphics[width=0.3\textwidth]{figure_man/lasso_hat.png}\\
-\includegraphics[width=0.95\textwidth]{figure/lasso_contour_cases.png}\\
-\end{figure}
+% We can also rewrite this as a constrained optimization problem. The penalty results in the constrained region to look like a diamond shape.
+% \vspace{-0.2cm}
+% \begin{eqnarray*}
+% \min_{\thetav} \sumin \left(\yi - \fxit\right)^2\,
+% \text{subject to: } \|\thetav\|_1 \leq t
+% \end{eqnarray*}
+% The kinks in $L1$ enforce sparse solutions because ``the loss contours first hit the sharp corners of the constraint'' at coordinate axes where (some) entries are zero. 
+% \vspace{-0.1cm}
+% \begin{figure}%\includegraphics[width=0.3\textwidth]{figure_man/lasso_hat.png}\\
+% \includegraphics[width=0.95\textwidth]{figure/lasso_contour_cases.png}\\
+% \end{figure}
 
-\end{vbframe}
+% \end{vbframe}
 
-\begin{vbframe}{$L1$ and $L2$ Reg. with Orthonormal Design}
-For the special case of orthonormal design $\Xmat^{\top}\Xmat=\id$ we can derive closed-form a solution in terms of $\thetah_{\text{OLS}}=(\Xmat^{\top}\Xmat)^{-1}\Xmat^{\top}\yv=\Xmat^{\top}\yv$:
-$$\thetah_{\text{Lasso}}=\text{sign}(\thetah_{\text{OLS}})(\vert \thetah_{\text{OLS}} \vert - \lambda)_{+}\quad(\text{sparsity})$$
+% \begin{vbframe}{$L1$ and $L2$ Reg. with Orthonormal Design}
+% For the special case of orthonormal design $\Xmat^{\top}\Xmat=\id$ we can derive closed-form a solution in terms of $\thetah_{\text{OLS}}=(\Xmat^{\top}\Xmat)^{-1}\Xmat^{\top}\yv=\Xmat^{\top}\yv$:
+% $$\thetah_{\text{Lasso}}=\text{sign}(\thetah_{\text{OLS}})(\vert \thetah_{\text{OLS}} \vert - \lambda)_{+}\quad(\text{sparsity})$$
 
-The function $S(\theta,\lambda):=\text{sign}(\theta)(|\theta|-\lambda)_{+}$ is called the \textbf{soft thresholding} operator: For $|\theta|<\lambda$ it returns $0$, whereas params $|\theta|>\lambda$ are shrunken toward $0$ by $\lambda$.\\
-\vspace{0.2cm}
-Comparing this to $\thetah_{\text{ridge}}$ under orthonormal design we see qualitatively different behavior as $\lambda \uparrow$:
-$$\thetah_{\text{ridge}}= ({\Xmat}^T \Xmat  + \lambda \id)^{-1} \Xmat^T\yv=((1+\lambda)\id)^{-1}\thetah_{\text{OLS}} = \frac{\thetah_{\text{OLS}}}{1+\lambda}\quad (\text{uniform downscaling})$$
+% The function $S(\theta,\lambda):=\text{sign}(\theta)(|\theta|-\lambda)_{+}$ is called the \textbf{soft thresholding} operator: For $|\theta|<\lambda$ it returns $0$, whereas params $|\theta|>\lambda$ are shrunken toward $0$ by $\lambda$.\\
+% \vspace{0.2cm}
+% Comparing this to $\thetah_{\text{ridge}}$ under orthonormal design we see qualitatively different behavior as $\lambda \uparrow$:
+% $$\thetah_{\text{ridge}}= ({\Xmat}^T \Xmat  + \lambda \id)^{-1} \Xmat^T\yv=((1+\lambda)\id)^{-1}\thetah_{\text{OLS}} = \frac{\thetah_{\text{OLS}}}{1+\lambda}\quad (\text{uniform downscaling})$$
 
-\end{vbframe}
+% \end{vbframe}
 
-\begin{vbframe}{Comparing Solution paths for $L1$/$L2$}
-\begin{itemize}
-    \item ridge regression results in a smooth solution path with non-sparse parameters
-    \item Lasso regression induces sparsity, but only for large enough $\lambda$
-\end{itemize}
- \lz
-\begin{figure}
-\includegraphics[width=0.9\textwidth]{figure_man/solution_paths_01.png}\\
-\end{figure}
+% \begin{vbframe}{Comparing Solution paths for $L1$/$L2$}
+% \begin{itemize}
+%     \item ridge regression results in a smooth solution path with non-sparse parameters
+%     \item Lasso regression induces sparsity, but only for large enough $\lambda$
+% \end{itemize}
+%  \lz
+% \begin{figure}
+% \includegraphics[width=0.9\textwidth]{figure_man/solution_paths_01.png}\\
+% \end{figure}
 
-\end{vbframe}
+% \end{vbframe}
 
-\begin{vbframe}{Effect of $L1$/$L2$ on Loss Surface}
-Regularized empirical risk $\riskr(\theta_1,\theta_2)$ using squared loss for $\lambda \uparrow$. $L1$ penalty makes non-smooth kinks at coordinate axes more pronounced, while $L2$ penalty warps $\riskr$ toward a ``basin'' (elliptic paraboloid). 
+% \begin{vbframe}{Effect of $L1$/$L2$ on Loss Surface}
+% Regularized empirical risk $\riskr(\theta_1,\theta_2)$ using squared loss for $\lambda \uparrow$. $L1$ penalty makes non-smooth kinks at coordinate axes more pronounced, while $L2$ penalty warps $\riskr$ toward a ``basin'' (elliptic paraboloid). 
 
-\begin{figure}
-    \begin{minipage}{0.32\linewidth}
-        \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam0.png}}
-        \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam0.png}}
-    \end{minipage}
-   \begin{minipage}{0.32\linewidth}
-        \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam1.png}}
-        \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam1.png}}
-    \end{minipage}
-    \begin{minipage}{0.32\linewidth}
-        \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam10.png}}
-        \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam10.png}}
-   \end{minipage}
-\end{figure}
+% \begin{figure}
+%     \begin{minipage}{0.32\linewidth}
+%         \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam0.png}}
+%         \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam0.png}}
+%     \end{minipage}
+%    \begin{minipage}{0.32\linewidth}
+%         \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam1.png}}
+%         \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam1.png}}
+%     \end{minipage}
+%     \begin{minipage}{0.32\linewidth}
+%         \centerline{\includegraphics[width=0.3\textwidth]{figure/reg_surfaces_l1_lam10.png}}
+%         \centerline{\includegraphics[width=\textwidth]{figure/reg_surfaces_l2_lam10.png}}
+%    \end{minipage}
+% \end{figure}
 
 %\begin{figure}
 %\includegraphics[width=0.8\textwidth]{figure/reg_surfaces_l1_l2.png}\\
 %\end{figure}
 
-\end{vbframe}
-\end{comment}
+% \end{vbframe}
 
 \endlecture
 \end{document}


### PR DESCRIPTION
- `slides-boosting-cwb-basics2`: issue was `\begin{comment}` and `\end{comment}`, switched to `%`
- `slides-boosting-gbm-classification`: `boosting_classif_title.PNG` moved to figure_man
- `slides-boosting-gbm-with-trees-2`: figure moved to figure_man (again)
- all the feature selection slides: same comment issue as `cwb-basics2`
- `linear-svm`: latex-math macro updates: `\Lyf` were not replaced (we moved to `\Lxy`)
- `nonlinear-svm`: figures moved to figure_man
- regularization: comment environments and citebuttons